### PR TITLE
Tidy version ID’s

### DIFF
--- a/src/django_browser_reload/static/django-browser-reload/reload-worker.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-worker.js
@@ -1,6 +1,6 @@
 let eventsPath = null;
 let port = null;
-let currentVersion = null;
+let currentVersionId = null;
 const defaultTimeoutMilliseconds = 100;
 let timeOutMilliseconds = defaultTimeoutMilliseconds;
 let eventSource = null;
@@ -54,14 +54,13 @@ connectToEvents = () => {
 
     const message = JSON.parse(event.data);
 
-    if (message.type == "version") {
-      if (currentVersion !== null && currentVersion !== message.version) {
+    if (message.type == "ping") {
+      if (currentVersionId !== null && currentVersionId !== message.versionId) {
         console.debug("🔁 Triggering reload.")
-        currentVersion = message.version
         port.postMessage("Reload")
       }
 
-      currentVersion = message.version;
+      currentVersionId = message.versionId;
     } else if (message.type === "templateChange") {
       port.postMessage("Reload")
     }

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,21 +31,21 @@ class TemplateChangedTests(SimpleTestCase):
 
 
 class EventsTests(SimpleTestCase):
-    def test_success_version_id(self):
+    def test_success_ping(self):
         response = self.client.get("/__reload__/events/")
 
         assert response.status_code == HTTPStatus.OK
         assert response["Content-Type"] == "text/event-stream"
         event = next(response.streaming_content)
         assert event == (
-            b'data: {"type": "version", "version": "'
-            + views.current_version.encode()
+            b'data: {"type": "ping", "versionId": "'
+            + views.version_id.encode()
             + b'"}\n\n'
         )
 
-    def test_success_version_id_twice(self):
-        with mock.patch.object(views, "VERSION_DELAY", 0.001):
-            response = self.client.get("/__reload__/events/")
+    @mock.patch.object(views, "PING_DELAY", 0.001)
+    def test_success_ping_twice(self):
+        response = self.client.get("/__reload__/events/")
 
         assert response.status_code == HTTPStatus.OK
         assert response["Content-Type"] == "text/event-stream"


### PR DESCRIPTION
* Call it a “version ID” rather than “version”, since it’s not incremental and doesn’t carry any meaning.
* Rename event to “ping” and use camelCase.