### PR TITLE
Tidy up a bit

### DIFF
--- a/src/django_browser_reload/static/django-browser-reload/reload-worker.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-worker.js
@@ -97,7 +97,7 @@ const connectToEvents = () => {
       }
 
       currentVersionId = message.versionId;
-    } else if (message.type === "templateChange") {
+    } else if (message.type === "reload") {
       port.postMessage("Reload");
     }
   });

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -22,15 +22,15 @@ class TemplateChangedTests(SimpleTestCase):
     def test_ignored(self):
         views.template_changed(file_path=Path("/tmp/nothing"))
 
-        assert not views.template_changed_event.is_set()
+        assert not views.should_reload_event.is_set()
 
     def test_success(self):
         path = settings.BASE_DIR / "templates" / "example.html"
 
         views.template_changed(file_path=path)
 
-        assert views.template_changed_event.is_set()
-        views.template_changed_event.clear()
+        assert views.should_reload_event.is_set()
+        views.should_reload_event.clear()
 
 
 @override_settings(DEBUG=True)
@@ -71,7 +71,7 @@ class EventsTests(SimpleTestCase):
 
     def test_success_template_change(self):
         response = self.client.get("/__reload__/events/")
-        views.template_changed_event.set()
+        views.should_reload_event.set()
 
         assert response.status_code == HTTPStatus.OK
         assert response["Content-Type"] == "text/event-stream"
@@ -79,4 +79,4 @@ class EventsTests(SimpleTestCase):
         next(response.streaming_content)
         event = next(response.streaming_content)
         assert event == b'data: {"type": "templateChange"}\n\n'
-        assert not views.template_changed_event.is_set()
+        assert not views.should_reload_event.is_set()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -78,5 +78,5 @@ class EventsTests(SimpleTestCase):
         # Skip version ID message
         next(response.streaming_content)
         event = next(response.streaming_content)
-        assert event == b'data: {"type": "templateChange"}\n\n'
+        assert event == b'data: {"type": "reload"}\n\n'
         assert not views.should_reload_event.is_set()


### PR DESCRIPTION
* Rename message type from `templateChange` to generic `reload`, ready for static asset support
* Rename threading event to generic name
* Break after finding a template reload match
* Document `message()` and design choice
* Fix type hint (not enforced without django-stubs anyway, should look at that)