### PR TITLE
Add default argument to os.environ.pop()

### DIFF
--- a/requirements/compile.py
+++ b/requirements/compile.py
@@ -7,7 +7,7 @@ from pathlib import Path
 if __name__ == "__main__":
     os.chdir(Path(__file__).parent)
     os.environ["CUSTOM_COMPILE_COMMAND"] = "requirements/compile.py"
-    os.environ.pop("PIP_REQUIRE_VIRTUALENV")
+    os.environ.pop("PIP_REQUIRE_VIRTUALENV", None)
     common_args = [
         "-m",
         "piptools",


### PR DESCRIPTION
Without this, if you attempt to run compile.py in an environment where the `PIP_REQUIRE_VIRTUALENV` variable is not set, you will get a `KeyError`