### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,5 @@ source =
 show_missing = True
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
