### PR TITLE
Improve Example Project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,11 +96,11 @@ This script connects back to the development server and will automatically reloa
 (Detecting modification of Django templates requires Django 3.2+.)
 The reload only happens in the most recently opened tab.
 
-Example App
+Example Project
 -----------
 
-See the `example app <https://github.com/adamchainz/django-browser-reload/tree/main/example>`__ in the ``example/`` directory of the GitHub repository.
-Start it up, and try modifying ``example/core/views.py`` or ``templates/*/index.html`` to see the reloading in action.
+See the `example project <https://github.com/adamchainz/django-browser-reload/tree/main/example>`__ in the ``example/`` directory of the GitHub repository.
+Start it up and modify its files to see the reloading in action.
 
 Template Tag
 ------------

--- a/example/README.rst
+++ b/example/README.rst
@@ -1,5 +1,5 @@
-Example Application
-===================
+Example Project
+===============
 
 Use Python 3.10 to set up and run with these commands:
 

--- a/example/requirements.in
+++ b/example/requirements.in
@@ -1,2 +1,3 @@
 django
 jinja2
+pywatchman

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -6,13 +6,13 @@
 #
 asgiref==3.4.1
     # via django
-django==3.2.7
+django==4.0.1
     # via -r requirements.in
 jinja2==3.0.3
     # via -r requirements.in
 markupsafe==2.0.1
     # via jinja2
-pytz==2021.3
-    # via django
+pywatchman==1.4.1
+    # via -r requirements.in
 sqlparse==0.4.2
     # via django


### PR DESCRIPTION
* Call it a “project“ rather than “app” to avoid confusion with “Django apps”.
* Avoid repetition in base README.
* Upgrade to Django 4.0.
* Add pywatchman, which unfortunately is broken on Python 3.10.