### PR TITLE
Debounce reload events

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* “Debounce” reload events with a 50 millisecond window.
+  This fixes an issue with repeat triggers of the same reload event.
+  It should also help workflows where several files change in quick succession.
+
 1.2.0 (2022-01-10)
 ------------------
 

--- a/src/django_browser_reload/views.py
+++ b/src/django_browser_reload/views.py
@@ -2,7 +2,7 @@ import json
 import threading
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Generator, Optional, Set
+from typing import Any, Generator, Optional, Set, Union
 
 import django
 from django.conf import settings
@@ -37,7 +37,7 @@ version_id = get_random_string(32)
 # Communicate template changes to the running polls thread
 should_reload_event = threading.Event()
 
-reload_timer: threading.Timer | None = None
+reload_timer: Union[threading.Timer, None] = None
 
 RELOAD_DEBOUNCE_TIME = 0.05  # seconds
 

--- a/src/django_browser_reload/views.py
+++ b/src/django_browser_reload/views.py
@@ -37,6 +37,19 @@ version_id = get_random_string(32)
 # Communicate template changes to the running polls thread
 should_reload_event = threading.Event()
 
+reload_timer: threading.Timer | None = None
+
+RELOAD_DEBOUNCE_TIME = 0.05  # seconds
+
+
+def trigger_reload_soon() -> None:
+    global reload_timer
+    if reload_timer is not None:
+        reload_timer.cancel()
+
+    reload_timer = threading.Timer(RELOAD_DEBOUNCE_TIME, should_reload_event.set)
+    reload_timer.start()
+
 
 def jinja_template_directories() -> Set[Path]:
     cwd = Path.cwd()
@@ -94,19 +107,19 @@ def on_file_changed(*, file_path: Path, **kwargs: Any) -> Optional[bool]:
     if HAVE_DJANGO_TEMPLATE_DIRECTORIES:
         for template_dir in django_template_directories():
             if template_dir in file_parents:
-                should_reload_event.set()
+                trigger_reload_soon()
                 return True
 
     # Jinja Templates
     for template_dir in jinja_template_directories():
         if template_dir in file_parents:
-            should_reload_event.set()
+            trigger_reload_soon()
             return True
 
     # Static assets
     for storage in static_finder_storages():
         if Path(storage.location) in file_parents:
-            should_reload_event.set()
+            trigger_reload_soon()
             return True
 
     return None

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,3 +1,4 @@
+import time
 from http import HTTPStatus
 from pathlib import Path
 from typing import List, Tuple
@@ -42,6 +43,7 @@ class OnFileChangedTests(SimpleTestCase):
     def test_ignored(self):
         views.on_file_changed(file_path=Path("/tmp/nothing"))
 
+        time.sleep(views.RELOAD_DEBOUNCE_TIME * 1.1)
         assert not views.should_reload_event.is_set()
 
     @django_3_2_plus
@@ -50,6 +52,7 @@ class OnFileChangedTests(SimpleTestCase):
 
         result = views.on_file_changed(file_path=path)
 
+        time.sleep(views.RELOAD_DEBOUNCE_TIME * 1.1)
         assert result is True
         assert views.should_reload_event.is_set()
         views.should_reload_event.clear()
@@ -59,6 +62,7 @@ class OnFileChangedTests(SimpleTestCase):
 
         result = views.on_file_changed(file_path=path)
 
+        time.sleep(views.RELOAD_DEBOUNCE_TIME * 1.1)
         assert result is True
         assert views.should_reload_event.is_set()
         views.should_reload_event.clear()
@@ -68,6 +72,7 @@ class OnFileChangedTests(SimpleTestCase):
 
         result = views.on_file_changed(file_path=path)
 
+        time.sleep(views.RELOAD_DEBOUNCE_TIME * 1.1)
         assert result is True
         assert views.should_reload_event.is_set()
         views.should_reload_event.clear()


### PR DESCRIPTION
For some reason I sometimes see multiple reload events in the example app, for saving a template once. Possibly there’s something in the way watchman watches the project + example app that causes extra events.

This PR fixes that by “debouncing” - starting a 50ms timer when we see a change, and restarting it out every time we get another change.
This is a good idea anyway as it will help workflows where multiple files change in quick succession, e.g. when running Tailwind and changing HTML that triggers a CSS change.