### PR TITLE
Support use with GzipMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Next
+------------------
+
+* Support using with GzipMiddleware
+
+
 1.7.0 (2023-02-25)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* Support using with GzipMiddleware
+* Support use with `GzipMiddleware`, or other middleware that encodes the response.
+
 1.7.0 (2023-02-25)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,7 @@
 Changelog
 =========
 
-Next
-------------------
-
 * Support using with GzipMiddleware
-
-
 1.7.0 (2023-02-25)
 ------------------
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django.middleware.gzip.GZipMiddleware",
     "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
 

--- a/src/django_browser_reload/views.py
+++ b/src/django_browser_reload/views.py
@@ -158,6 +158,6 @@ def events(request: HttpRequest) -> HttpResponseBase:
         event_stream(),
         content_type="text/event-stream",
     )
-    # Set a Content-Encoding to bypass GzipMiddleware
-    response["Content-Encoding"] = ""
+    # Set a content-encoding to bypass GzipMiddleware etc.
+    response["content-encoding"] = ""
     return response

--- a/src/django_browser_reload/views.py
+++ b/src/django_browser_reload/views.py
@@ -154,7 +154,10 @@ def events(request: HttpRequest) -> HttpResponseBase:
                 should_reload_event.clear()
                 yield message("reload")
 
-    return StreamingHttpResponse(
+    response = StreamingHttpResponse(
         event_stream(),
         content_type="text/event-stream",
     )
+    # Set a Content-Encoding to bypass GzipMiddleware
+    response["Content-Encoding"] = ""
+    return response

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -126,7 +126,8 @@ class EventsTests(SimpleTestCase):
     def test_success_template_change_with_gzip(self):
         # https://github.com/typeddjango/django-stubs/pull/1421
         middleware = GZipMiddleware(views.events)  # type: ignore[arg-type]
-        response = middleware(RequestFactory(HTTP_ACCEPT_ENCODING="gzip").get("/"))
+        request = RequestFactory(HTTP_ACCEPT_ENCODING="gzip").get("/")
+        response = middleware(request)
         assert isinstance(response, StreamingHttpResponse)
         views.should_reload_event.set()
 


### PR DESCRIPTION
GzipMiddleware seems to buffer a StreamingHttpResponse, effectively breaking Server-Sent Events