### PR TITLE
Use lowercase header names everywhere

### DIFF
--- a/src/django_browser_reload/middleware.py
+++ b/src/django_browser_reload/middleware.py
@@ -62,8 +62,8 @@ class BrowserReloadMiddleware:
         if (
             not settings.DEBUG
             or getattr(response, "streaming", False)
-            or response.get("Content-Encoding", "")
-            or response.get("Content-Type", "").split(";", 1)[0] != "text/html"
+            or response.headers.get("content-encoding", "")
+            or response.headers.get("content-type", "").split(";", 1)[0] != "text/html"
         ):
             return
 
@@ -81,5 +81,5 @@ class BrowserReloadMiddleware:
         tail = content[match.end() :]
 
         response.content = head + django_browser_reload_script() + tag + tail
-        if "Content-Length" in response:
-            response["Content-Length"] = len(response.content)
+        if "content-length" in response.headers:
+            response["content-length"] = len(response.content)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -95,7 +95,7 @@ class EventsTests(SimpleTestCase):
         assert isinstance(response, StreamingHttpResponse)
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
+        assert response.headers["content-type"] == "text/event-stream"
         response_iterable = iter(response)
         event = next(response_iterable)
         assert event == (
@@ -110,7 +110,7 @@ class EventsTests(SimpleTestCase):
         assert isinstance(response, StreamingHttpResponse)
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
+        assert response.headers["content-type"] == "text/event-stream"
         response_iterable = iter(response)
         event1 = next(response_iterable)
         event2 = next(response_iterable)
@@ -122,7 +122,7 @@ class EventsTests(SimpleTestCase):
         views.should_reload_event.set()
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
+        assert response.headers["content-type"] == "text/event-stream"
         response_iterable = iter(response)
         # Skip version ID message
         next(response_iterable)
@@ -138,8 +138,8 @@ class EventsTests(SimpleTestCase):
         views.should_reload_event.set()
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
-        assert response["Content-Encoding"] == ""
+        assert response.headers["content-type"] == "text/event-stream"
+        assert response.headers["content-encoding"] == ""
         response_iterable = iter(response)
         # Skip version ID message
         next(response_iterable)
@@ -172,7 +172,7 @@ class AsyncEventsTests(SimpleTestCase):
         assert isinstance(response, StreamingHttpResponse)
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
+        assert response.headers["content-type"] == "text/event-stream"
 
         event = await anext(aiter(response))
         assert event == (
@@ -188,7 +188,7 @@ class AsyncEventsTests(SimpleTestCase):
         assert isinstance(response, StreamingHttpResponse)
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
+        assert response.headers["content-type"] == "text/event-stream"
         response_iter = aiter(response)
         event1 = await anext(response_iter)
         event2 = await anext(response_iter)
@@ -201,7 +201,7 @@ class AsyncEventsTests(SimpleTestCase):
         views.should_reload_event.set()
 
         assert response.status_code == HTTPStatus.OK
-        assert response["Content-Type"] == "text/event-stream"
+        assert response.headers["content-type"] == "text/event-stream"
         response_iter = aiter(response)
         # Skip version ID message
         await anext(response_iter)
@@ -214,5 +214,5 @@ class AsyncEventsTests(SimpleTestCase):
         response = await self.async_client.get("/__reload__/events/")
 
         assert response.status_code == HTTPStatus.NOT_IMPLEMENTED
-        assert response["content-type"] == "text/plain"
+        assert response.headers["content-type"] == "text/plain"
         assert response.content == b"ASGI requires Django 4.2+"


### PR DESCRIPTION
For consistency with HTTP/2+