### PR TITLE
Restart Django development server on Python file changes

### DIFF
--- a/src/django_browser_reload/views.py
+++ b/src/django_browser_reload/views.py
@@ -104,28 +104,41 @@ def on_autoreload_started(*, sender: BaseReloader, **kwargs: Any) -> None:
 @receiver(file_changed, dispatch_uid="browser_reload")
 def on_file_changed(*, file_path: Path, **kwargs: Any) -> bool | None:
     # Returning True tells Django *not* to reload
-
     file_parents = file_path.parents
 
     # Django Templates
     for template_dir in django_template_directories():
         if template_dir in file_parents:
             trigger_reload_soon()
-            return True
+            return skip_server_restart(file_path)
 
     # Jinja Templates
     for template_dir in jinja_template_directories():
         if template_dir in file_parents:
             trigger_reload_soon()
-            return True
+            return skip_server_restart(file_path)
 
     # Static assets
     for storage in static_finder_storages():
         if Path(storage.location) in file_parents:
             trigger_reload_soon()
-            return True
+            return skip_server_restart(file_path)
 
     return None
+
+
+def skip_server_restart(file_path: Path) -> bool | None:
+    """
+    Return None if the server should be restarted and True otherwise.
+
+    This function is called from on_file_changed() where we already know that the file
+    is either a template or a static asset. By default, the server should not be
+    restarted. However, if the file is a Python file (such as with django-components),
+    we want to restart the server regardless.
+    """
+    if file_path.suffix == ".py":
+        return None
+    return True
 
 
 def message(type_: str, **kwargs: Any) -> bytes:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -42,7 +42,8 @@ class OnAutoreloadStartedTests(SimpleTestCase):
 
 class OnFileChangedTests(SimpleTestCase):
     def test_ignored(self):
-        views.on_file_changed(file_path=Path("/tmp/nothing"))
+        result = views.on_file_changed(file_path=Path("/tmp/nothing"))
+        assert result is None
 
         time.sleep(views.RELOAD_DEBOUNCE_TIME * 1.1)
         assert not views.should_reload_event.is_set()
@@ -76,6 +77,25 @@ class OnFileChangedTests(SimpleTestCase):
         assert result is True
         assert views.should_reload_event.is_set()
         views.should_reload_event.clear()
+
+    def test_python_file_in_templates_or_static(self):
+        # Force server reload when Python files are changed even if they are in
+        # templates or static directories
+        paths = [
+            settings.BASE_DIR / "templates" / "django" / "component.py",
+            settings.BASE_DIR / "templates" / "jinja" / "component.py",
+            settings.BASE_DIR / "static" / "component.py",
+        ]
+        for path in paths:
+            with self.subTest(path=path):
+                result = views.on_file_changed(file_path=path)
+
+                time.sleep(views.RELOAD_DEBOUNCE_TIME * 1.1)
+                # Don't prevent Django from reloading
+                assert result is None
+                # But also reload the browser
+                assert views.should_reload_event.is_set()
+                views.should_reload_event.clear()
 
 
 @override_settings(DEBUG=True)


### PR DESCRIPTION
Force server reload when Python files are changed even if they are in
templates or static directories.

Fixes #224
