### PR TITLE
Support to disable/enable browser reload

### DIFF
--- a/src/django_browser_reload/jinja.py
+++ b/src/django_browser_reload/jinja.py
@@ -15,8 +15,10 @@ def django_browser_reload_script() -> str:
             + ' data-worker-script-path="{}"'
             + ' data-events-path="{}"'
             + " defer></script>"
+            + '<link rel="stylesheet" href="{}">'
         ),
         static("django-browser-reload/reload-listener.js"),
         static("django-browser-reload/reload-worker.js"),
         reverse("django_browser_reload:events"),
+        static("django-browser-reload/django-browser-reload.css"),
     )

--- a/src/django_browser_reload/static/django-browser-reload/django-browser-reload.css
+++ b/src/django_browser_reload/static/django-browser-reload/django-browser-reload.css
@@ -1,0 +1,42 @@
+#djangoBrowserReloadToggle {
+  display: flex;
+  flex-direction: row;
+}
+#djangoBrowserReloadToggle > * {
+  color: #f1f1f1;
+  font-size: 1.5rem;
+  line-height: 1.5rem;
+  font-weight: bold;
+  font-family: "Segoe UI", system-ui, Roboto, "Helvetica Neue", Arial,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
+}
+#djangoBrowserReloadToggle.djbr-disabled > * {
+  text-decoration: line-through;
+}
+#djangoBrowserReloadToggle > span {
+  color: #157a53;
+}
+
+#djangoBrowserReloadContainer {
+  opacity: 0.1;
+  position: fixed;
+  bottom: 0;
+  cursor: move;
+  border: 1px solid white;
+  background-color: black;
+  border-bottom: 0;
+  padding: 3px;
+  z-index: 999;
+}
+#djangoBrowserReloadContainer:hover {
+  opacity: 0.9;
+  border: 1px solid #111;
+  background-color: #f1f1f1;
+}
+#djangoBrowserReloadContainer:hover #djangoBrowserReloadToggle > * {
+  color: black;
+}
+#djangoBrowserReloadContainer:hover #djangoBrowserReloadToggle > span {
+  color: #0c4a32;
+}

--- a/src/django_browser_reload/static/django-browser-reload/reload-listener.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-listener.js
@@ -5,6 +5,86 @@
   const workerScriptPath = dataset.workerScriptPath
   const eventsPath = dataset.eventsPath
 
+  const userPreference = localStorage.getItem('django-browser-reload:Enabled')
+  let reloadEnabled = userPreference === 'true' || userPreference === null
+
+  const addReloadContainer = () => {
+    const browserReloadContainer = document.createElement('div')
+    browserReloadContainer.id = 'djangoBrowserReloadContainer'
+
+    const toggleButton = document.createElement('div')
+    toggleButton.id = 'djangoBrowserReloadToggle'
+    toggleButton.innerHTML = '<span>dj</span><div>BR</span>'
+
+    if (!reloadEnabled) {
+      toggleButton.classList.add('djbr-disabled')
+    }
+
+    browserReloadContainer.appendChild(toggleButton)
+    document.body.appendChild(browserReloadContainer)
+
+    const maxLeft =
+      document.documentElement.clientWidth - browserReloadContainer.offsetWidth
+    const containerLeft = Math.min(
+      localStorage.getItem('django-browser-reload:Left') || maxLeft,
+      maxLeft
+    )
+    browserReloadContainer.style.left = containerLeft + 'px'
+
+    let startX
+    let initialX
+    let containerDragged = false
+
+    toggleButton.addEventListener('click', () => {
+      if (!containerDragged) {
+        reloadEnabled = !reloadEnabled
+        localStorage.setItem('django-browser-reload:Enabled', reloadEnabled)
+        toggleButton.classList.toggle('djbr-disabled')
+      }
+    })
+
+    const buttonMouseMove = (evt) => {
+      if (containerDragged || evt.pageX !== startX) {
+        let left = initialX + evt.pageX
+        if (left < 0) {
+          left = 0
+        } else if (
+          left + browserReloadContainer.offsetWidth >
+          document.documentElement.clientWidth
+        ) {
+          left =
+            document.documentElement.clientWidth -
+            browserReloadContainer.offsetWidth
+        }
+        browserReloadContainer.style.left = left + 'px'
+        containerDragged = true
+      }
+    }
+
+    const buttonMouseUp = (evt) => {
+      document.removeEventListener('mousemove', buttonMouseMove)
+      if (containerDragged) {
+        evt.preventDefault()
+        localStorage.setItem(
+          'django-browser-reload:Left',
+          browserReloadContainer.offsetLeft
+        )
+        requestAnimationFrame(function () {
+          containerDragged = false
+        })
+      }
+      document.removeEventListener('mouseup', buttonMouseUp)
+    }
+
+    toggleButton.addEventListener('mousedown', function (evt) {
+      evt.preventDefault()
+      startX = evt.pageX
+      initialX = browserReloadContainer.offsetLeft - startX
+      document.addEventListener('mousemove', buttonMouseMove)
+      document.addEventListener('mouseup', buttonMouseUp)
+    })
+  }
+
   if (!window.SharedWorker) {
     console.debug('😭 django-browser-reload cannot work in this browser.')
   } else {
@@ -13,7 +93,7 @@
     })
 
     worker.port.addEventListener('message', (event) => {
-      if (event.data === 'Reload') {
+      if (reloadEnabled && event.data === 'Reload') {
         location.reload()
       }
     })
@@ -24,5 +104,7 @@
     })
 
     worker.port.start()
+
+    document.addEventListener('DOMContentLoaded', addReloadContainer)
   }
 }

--- a/tests/templatetags/test_django_browser_reload.py
+++ b/tests/templatetags/test_django_browser_reload.py
@@ -25,4 +25,6 @@ class DjangoBrowserReloadScriptTests(SimpleTestCase):
             + ' data-worker-script-path="/static/django-browser-reload/'
             + 'reload-worker.js"'
             + ' data-events-path="/__reload__/events/" defer></script>'
+            + '<link rel="stylesheet" href="/static/django-browser-reload/'
+            + 'django-browser-reload.css">'
         )

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -21,4 +21,6 @@ class DjangoBrowserReloadScriptTests(SimpleTestCase):
             + ' data-worker-script-path="/static/django-browser-reload/'
             + 'reload-worker.js"'
             + ' data-events-path="/__reload__/events/" defer></script>'
+            + '<link rel="stylesheet" href="/static/django-browser-reload/'
+            + 'django-browser-reload.css">'
         )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -86,6 +86,8 @@ class BrowserReloadMiddlewareTests(SimpleTestCase):
             + b' data-worker-script-path="/static/django-browser-reload/'
             + b'reload-worker.js"'
             + b' data-events-path="/__reload__/events/" defer></script>'
+            + b'<link rel="stylesheet" href="/static/django-browser-reload/'
+            + b'django-browser-reload.css">'
             + b"</body></html>"
         )
 
@@ -106,6 +108,8 @@ class BrowserReloadMiddlewareTests(SimpleTestCase):
             + b' data-worker-script-path="/static/django-browser-reload/'
             + b'reload-worker.js"'
             + b' data-events-path="/__reload__/events/" defer></script>'
+            + b'<link rel="stylesheet" href="/static/django-browser-reload/'
+            + b'django-browser-reload.css">'
             + b"</body></html>"
         )
 
@@ -121,6 +125,8 @@ class BrowserReloadMiddlewareTests(SimpleTestCase):
             + b' data-worker-script-path="/static/django-browser-reload/'
             + b'reload-worker.js"'
             + b' data-events-path="/__reload__/events/" defer></script>'
+            + b'<link rel="stylesheet" href="/static/django-browser-reload/'
+            + b'django-browser-reload.css">'
             + b"</body></html>"
         )
 
@@ -136,5 +142,7 @@ class BrowserReloadMiddlewareTests(SimpleTestCase):
             + b' data-worker-script-path="/static/django-browser-reload/'
             + b'reload-worker.js"'
             + b' data-events-path="/__reload__/events/" defer></script>'
+            + b'<link rel="stylesheet" href="/static/django-browser-reload/'
+            + b'django-browser-reload.css">'
             + b"</body></html>"
         )


### PR DESCRIPTION
There are some cases where a change on the project files doesn't have to refresh the current browser page. This PR aims to add the ability to disable/enable the reload easily on the same browser.

To achieve that this PR adds a small container:
![image](https://github.com/adamchainz/django-browser-reload/assets/75857767/4fe029bd-f694-410e-89eb-8c61287e55fd)
Which the user can move around:

https://github.com/adamchainz/django-browser-reload/assets/75857767/ed261994-d6fc-4d88-ba13-636d3a6c3c40

And which the user can click to disable the browser reload:
![image](https://github.com/adamchainz/django-browser-reload/assets/75857767/57535409-49b0-414f-a65c-8fd97089c524)
Or enable it:
![image](https://github.com/adamchainz/django-browser-reload/assets/75857767/b1eb6ed1-5770-4818-bb51-08248925ab3d)

