### PR TITLE
Mark view with @login_not_required

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Mark the view as public with ``@login_not_required`` on Django 5.1, for compatibility with ``LoginRequiredMiddleware``.
+
+  Thanks to Macktireh Abdi Soubaneh for the report in `Issue #281 <https://github.com/adamchainz/django-browser-reload/issues/281>`__.
+
 1.13.0 (2024-06-19)
 -------------------
 

--- a/src/django_browser_reload/views.py
+++ b/src/django_browser_reload/views.py
@@ -187,3 +187,12 @@ def events(request: HttpRequest) -> HttpResponseBase:
     # Set a content-encoding to bypass GzipMiddleware etc.
     response["content-encoding"] = ""
     return response
+
+
+if django.VERSION >= (5, 1):
+    # isort: off
+    from django.contrib.auth.decorators import login_not_required  # type: ignore [attr-defined]
+
+    # isort: on
+
+    events = login_not_required(events)


### PR DESCRIPTION
Fixes #281.

Tested with this patch to the example project:

```diff
diff --git example/example/settings.py example/example/settings.py
index 14ce460..b6f7542 100644
--- example/example/settings.py
+++ example/example/settings.py
@@ -23,16 +23,24 @@
     # Third Party
     "django_browser_reload",
     # Contrib
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
     "django.contrib.staticfiles",
 ]
 if asgi:
     INSTALLED_APPS.insert(1, "daphne")
 
 MIDDLEWARE = [
     "django.middleware.gzip.GZipMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.auth.middleware.LoginRequiredMiddleware",
     "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
 
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
 ROOT_URLCONF = "example.urls"
 
 SECRET_KEY = "django-insecure-WCglZv2CA4v59K24bXfADwNDXc3HlwDY"
diff --git example/example/views.py example/example/views.py
index 585afec..3772a81 100644
--- example/example/views.py
+++ example/example/views.py
@@ -5,8 +5,11 @@
 from django.shortcuts import render
 from django.views.decorators.http import require_GET
 
+from django.contrib.auth.decorators import login_not_required
+
 
 @require_GET
+@login_not_required
 def index_django(request: HttpRequest) -> HttpResponse:
     return render(
         request,
@@ -18,6 +21,7 @@ def index_django(request: HttpRequest) -> HttpResponse:
 
 
 @require_GET
+@login_not_required
 def index_jinja(request: HttpRequest) -> HttpResponse:
     return render(
         request,
@@ -30,6 +34,7 @@ def index_jinja(request: HttpRequest) -> HttpResponse:
 
 
 @require_GET
+@login_not_required
 def favicon(request: HttpRequest) -> HttpResponse:
     return HttpResponse(
         (
```


But I don’t think it’s worth merging and maintaining all those extra dependencies, in the example project or tests.