### PR TITLE
debug for webpack support

### DIFF
--- a/src/django_browser_reload/static/django-browser-reload/reload-listener.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-listener.js
@@ -14,7 +14,11 @@
 
     worker.port.addEventListener('message', (event) => {
       if (event.data === 'Reload') {
-        location.reload()
+          setTimeout(() => {
+            // add some delay for webpack to poll
+            location.reload()
+          }, 1000)
+          //location.reload()
       }
     })
 

--- a/src/django_browser_reload/static/django-browser-reload/reload-listener.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-listener.js
@@ -14,11 +14,11 @@
 
     worker.port.addEventListener('message', (event) => {
       if (event.data === 'Reload') {
-          setTimeout(() => {
-            // add some delay for webpack to poll
-            location.reload()
-          }, 1000)
-          //location.reload()
+        setTimeout(() => {
+          // add some delay for webpack to poll
+          location.reload()
+        }, 1000)
+        // location.reload()
       }
     })
 

--- a/src/django_browser_reload/static/django-browser-reload/reload-worker.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-worker.js
@@ -5,6 +5,8 @@ let eventsPath = null
 let port = null
 let currentVersionId = null
 let eventSource = null
+let debounce_reload = false
+
 
 addEventListener('connect', (event) => {
   // Only keep one active port, for whichever tab was last loaded.
@@ -98,6 +100,11 @@ const connectToEvents = () => {
       }
 
       currentVersionId = message.versionId
+      // currentVersionId was null, if django source change
+      if (!debounce_reload){
+        port.postMessage('Reload')
+        debounce_reload = true
+      }
     } else if (message.type === 'reload') {
       port.postMessage('Reload')
     }

--- a/src/django_browser_reload/static/django-browser-reload/reload-worker.js
+++ b/src/django_browser_reload/static/django-browser-reload/reload-worker.js
@@ -7,7 +7,6 @@ let currentVersionId = null
 let eventSource = null
 let debounce_reload = false
 
-
 addEventListener('connect', (event) => {
   // Only keep one active port, for whichever tab was last loaded.
   if (port) {
@@ -101,7 +100,7 @@ const connectToEvents = () => {
 
       currentVersionId = message.versionId
       // currentVersionId was null, if django source change
-      if (!debounce_reload){
+      if (!debounce_reload) {
         port.postMessage('Reload')
         debounce_reload = true
       }


### PR DESCRIPTION
I am using webpack for livereload for my stylesheets, javascript. 
I also want Django source edit to reload my browser.
this would save me hundred clicks a day...

Django is running on dev runserver.
My attempt to get the webpack frontend proxy to reload from reload_worker.js signals.